### PR TITLE
cloud animation optimization

### DIFF
--- a/assets/css/_animations.styl
+++ b/assets/css/_animations.styl
@@ -6,13 +6,8 @@
     transform: rotate(360deg)
 
 @keyframes drift
-  0%
-    left: -120px
-  100%
-    left: 100vw
-
-@keyframes drift-reverse
-  0%
-    left: 100vw
-  100%
-    left: -120px
+  from
+    transform: translate(0,0)
+  to
+    transform: translate(100vw, 0)
+    

--- a/assets/css/_index.styl
+++ b/assets/css/_index.styl
@@ -68,6 +68,7 @@
 
   .clouds img
     absolute: top left -120px
+    transform: translate(0,0)
     animation-timing-function: linear
     animation-iteration-count: infinite
 
@@ -79,8 +80,10 @@
 
     &:nth-child(2)
       top: 14vw
-      left: 100vw
-      animation-name: drift-reverse
+      left: 0
+      transform: translate(100vw, 0)
+      animation-name: drift
+      animation-direction: reverse
       animation-duration: 120s
 
     &:nth-child(3)


### PR DESCRIPTION
By removing the animation on the position `left`, we stop redrawing the div; which will improve cpu usage on all devices. Switching the animation to `from`/`to` we are able to reverse the original animation for the second cloud.
