### PR TITLE
document new open_browser url feature

### DIFF
--- a/docs/configuration.jade
+++ b/docs/configuration.jade
@@ -67,7 +67,7 @@ block content
 
     ##### open_browser
 
-    When enabled, `roots watch` will automatically open a browser to the local server.    
+    When enabled, `roots watch` will automatically open a browser to the local server. You can also pass a string which will be proxied to the `open()` function, allowing you to open an external URL besides localhost after each compile.   
     _default:_ `true`
 
     ##### locals


### PR DESCRIPTION
add a note about being able to pass a URL to the `open_browser` option

**note:** this should be merged only once https://github.com/jenius/roots/pull/613 has been released. 