### PR TITLE
Lock Jeet version to 6.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dynamic-content": "0.3.x",
     "highlight.js": "8.x",
     "jade": "1.x",
-    "jeet": "6.x",
+    "jeet": "6.0.x",
     "jstransformer-marked": "^1.0.1",
     "lodash.debounce": "3.x",
     "lodash.find": "3.x",


### PR DESCRIPTION
In version 6.1.14 of Jeet, importing via alias no longer works,
preventing compilation of CSS assets.

The dependency should be frozen to 6.0 until the issue is resolved (and
a fix published).

See https://github.com/mojotech/jeet/issues/493